### PR TITLE
Add pdf-cell padding and pdf-table width percent

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,6 +837,7 @@ metadata:
 * :bounding-box `[width height]`
 * :horizontal-align :left, :rigth, :center, :justified
 * :title string
+* :width-percent number (0-100)
 
 ```clojure
 [:pdf-table
@@ -906,6 +907,11 @@ optional metadata:
 * :border-width-left number
 * :border-width-right number
 * :border-width-top number
+* :padding number (or a [CSS-like](https://developer.mozilla.org/en-US/docs/Web/CSS/padding#Examples) vector of numbers)
+* :padding-bottom number
+* :padding-left number
+* :padding-right number
+* :padding-top number
 * :rotation number - rotates the cell
 * :height - number
 * :min-height - number

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -463,7 +463,7 @@
 
     tbl))
 
-(defn- pdf-table [{:keys [color spacing-before spacing-after cell-border bounding-box num-cols horizontal-align table-events]
+(defn- pdf-table [{:keys [color spacing-before spacing-after cell-border bounding-box num-cols horizontal-align table-events width-percent]
                   :as meta}
                   widths
                   & rows]
@@ -473,6 +473,8 @@
 
   (let [cols (or num-cols (apply max (map count rows)))
         tbl (new PdfPTable cols)]
+
+    (when width-percent (.setWidthPercentage tbl (float width-percent)))
 
     (if bounding-box
       (let [[x y] bounding-box]

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -316,6 +316,21 @@
     (doto (new Cell) (.addElement (make-section meta element)))))
 
 
+(defn- pdf-cell-padding*
+  ([cell a]       (.setPadding cell (float a)))
+  ([cell a b]     (pdf-cell-padding* cell a b a b))
+  ([cell a b c]   (pdf-cell-padding* cell a b c b))
+  ([cell a b c d]
+   (doto cell
+     (.setPaddingTop    (float a))
+     (.setPaddingRight  (float b))
+     (.setPaddingBottom (float c))
+     (.setPaddingLeft   (float d)))))
+
+(defn- pdf-cell-padding [cell pad]
+  (when-let [args (if (sequential? pad) pad [pad])]
+    (apply pdf-cell-padding* cell args)))
+
 (defn- pdf-cell [meta element]
   (cond
     (nil? element) (make-section [:pdf-cell [:chunk meta ""]])
@@ -339,6 +354,11 @@
                       border-width-left
                       border-width-right
                       border-width-top
+                      padding
+                      padding-bottom
+                      padding-left
+                      padding-right
+                      padding-top
                       rotation
                       height
                       min-height]} (second element)
@@ -356,6 +376,11 @@
           (if border-width-left (.setBorderWidthLeft c (float border-width-left)))
           (if border-width-right (.setBorderWidthRight c  (float border-width-right)))
           (if border-width-top (.setBorderWidthTop c (float border-width-top)))
+          (if padding (pdf-cell-padding c padding))
+          (if padding-bottom (.setPaddingBottom c (float padding-bottom)))
+          (if padding-left (.setPaddingLeft c (float padding-left)))
+          (if padding-right (.setPaddingRight c  (float padding-right)))
+          (if padding-top (.setPaddingTop c (float padding-top)))
           (if rotation (.setRotation c (int rotation)))
           (if height (.setFixedHeight c (float height)))
           (if min-height (.setMinimumHeight c (float min-height)))


### PR DESCRIPTION
Just wanted to be able to set pdf-table width percentage and pdf-cell padding:

```clj
  [:pdf-table
   {:width-percent 100}
   [1 1 1 1 1 1]
   [[:pdf-cell {:colspan 6 :padding 10} [:heading "Hello World"]]]
   ...
```

I went ahead allowed padding to be a vector of 1-4 numbers, a la [CSS padding](https://developer.mozilla.org/en-US/docs/Web/CSS/padding).