### PR TITLE
rename color to background-color in cell and pdf-cell, and add border-color to pdf-cell

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ optional metadata:
 * :rowspan number
 * :border boolean
 * :set-border `[:top :bottom :left :right]` list of enabled borders, pass empty vector to disable all borders
+* :border-color `[r g b]`
 * :border-width number
 * :border-width-bottom number
 * :border-width-left number

--- a/README.md
+++ b/README.md
@@ -882,7 +882,7 @@ tag :cell
 metadata:
 
 * :align :left, :center, :right, :justified
-* :color `[r g b]` (int values)
+* :background-color `[r g b]` (int values)
 * :colspan number
 * :border boolean
 * :set-border `[:top :bottom :left :right]` list of enabled borders, pass empty vector to disable all borders
@@ -918,7 +918,7 @@ tag :pdf-cell
 
 optional metadata:
 
-* :color `[r g b]`
+* :background-color `[r g b]`
 * :align :left, :center, :right, :justified
 * :valign :top, :middle, :bottom
 * :colspan number
@@ -1130,7 +1130,7 @@ creating a pdf:
        {:style "italic" :size 18 :family "halvetica" :color [200 55 221]}
        "Hello Clojure!"]]
      "baz"]
-    ["foo1" [:cell {:color [100 10 200]} "bar1"] "baz1"]
+    ["foo1" [:cell {:background-color [100 10 200]} "bar1"] "baz1"]
     ["foo2" "bar2" [:cell ["table" ["Inner table Col1" "Inner table Col2" "Inner table Col3"]]]]]
 
    [:paragraph

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -273,7 +273,7 @@
 
 
 
-(defn- cell [{:keys [color
+(defn- cell [{:keys [background-color
                      colspan
                      rowspan
                      border
@@ -287,7 +287,7 @@
              content]
 
   (let [c (if (string? content) (new Cell (styled-item meta content)) (new Cell))
-        [r g b] color]
+        [r g b] background-color]
 
     (if (and r g b) (.setBackgroundColor c (new Color (int r) (int g) (int b))))
     (when (not (nil? border))
@@ -321,7 +321,7 @@
   (when-let [args (if (sequential? pad) pad [pad])]
     (apply pdf-cell-padding* cell args)))
 
-(defn- pdf-cell [{:keys [color
+(defn- pdf-cell [{:keys [background-color
                          colspan
                          rowspan
                          border
@@ -343,7 +343,7 @@
                          min-height] :as meta}
                  content]
   (let [c (if (string? content) (new PdfPCell (pdf-styled-item meta content)) (new PdfPCell))
-        [r g b] color]
+        [r g b] background-color]
 
     (if (and r g b) (.setBackgroundColor c (new Color (int r) (int g) (int b))))
     (when (not (nil? border))

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -679,8 +679,10 @@
             tag (if (string? element-name) (keyword element-name) element-name)
             [tag & classes] (split-classes-from-tag tag)
             class-attrs (get-class-attributes (:stylesheet meta) classes)
-            [params elements] (if (map? h) [(merge meta h) t] [meta content])
-            params (merge class-attrs params)]
+            new-meta (cond-> meta
+                       class-attrs (merge class-attrs)
+                       (map? h)    (merge h))
+            elements (if (map? h) t content)]
 
         (apply
           (condp = tag
@@ -708,7 +710,7 @@
             :table       table
             :pdf-table   pdf-table
             (throw (new Exception (str "invalid tag: " tag " in element: " element) )))
-          (cons params elements))))))
+          (cons new-meta elements))))))
 
  (defn- append-to-doc [stylesheet references font-style width height item doc pdf-writer]
    (if (= [:pagebreak] item)

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -469,7 +469,7 @@
                   :else             [:pdf-cell content])]
     (.addCell tbl (make-section meta element))))
 
-(defn- pdf-table [{:keys [background-color spacing-before spacing-after cell-border bounding-box num-cols horizontal-align table-events width-percent]
+(defn- pdf-table [{:keys [spacing-before spacing-after cell-border bounding-box num-cols horizontal-align table-events width-percent]
                   :as meta}
                   widths
                   & rows]
@@ -493,7 +493,6 @@
     (when (= false cell-border)
       (doto (.getDefaultCell tbl) (.setBorder Rectangle/NO_BORDER)))
 
-    (if background-color (let [[r g b] background-color] (.setBackgroundColor tbl (new Color (int r) (int g) (int b)))))
     (if spacing-before (.setSpacingBefore tbl (float spacing-before)))
     (if spacing-after (.setSpacingAfter tbl (float spacing-after)))
 

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -279,6 +279,7 @@
                      border
                      align
                      set-border
+                     border-color
                      border-width
                      border-width-bottom
                      border-width-left
@@ -328,6 +329,7 @@
                          align
                          valign
                          set-border
+                         border-color
                          border-width
                          border-width-bottom
                          border-width-left
@@ -342,10 +344,14 @@
                          height
                          min-height] :as meta}
                  content]
-  (let [c (if (string? content) (new PdfPCell (pdf-styled-item meta content)) (new PdfPCell))
-        [r g b] background-color]
+  (let [c (if (string? content) (new PdfPCell (pdf-styled-item meta content)) (new PdfPCell))]
 
-    (if (and r g b) (.setBackgroundColor c (new Color (int r) (int g) (int b))))
+    (let [[r g b] background-color]
+      (if (and r g b) (.setBackgroundColor c (new Color (int r) (int g) (int b)))))
+
+    (let [[r g b] border-color]
+      (if (and r g b) (.setBorderColor c (new Color (int r) (int g) (int b)))))
+
     (when (not (nil? border))
       (.setBorder c (if border Rectangle/BOX Rectangle/NO_BORDER)))
 


### PR DESCRIPTION
Same rename as b0ecd2d6e691cf0d1153bf30c70abf5a91dbfc89 but for cell and pdf-cell.  Since this (and the previous) is a breaking change, should probably increment the major version number.

And just exposing border-color in pdf-cell.