### PR TITLE
Unicode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ A font is defined by a map consisting of the following parameters, all parameter
 
 * :family has following options: :courier, :helvetica, :times-roman, :symbol, :zapfdingbats defaults to :helvetica
 * :ttf-name is the name of a TTF font installed on the system. Overrides :family parameter.
+* :encoding should be set to :unicode to enable unicode support if custom :ttf-name font is used
 * :size is a number default is 10
 * :style has following options: :bold, :italic, :bold-italic, :normal, :strikethru, :underline defaults to :normal
 * :styles a vector of multiple style keys

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -83,7 +83,8 @@
     size     :size
     [r g b]  :color
     family   :family
-    ttf-name :ttf-name}]
+    ttf-name :ttf-name
+    encoding :encoding}]
     (FontFactory/getFont
       (if-not (nil? ttf-name)
         ttf-name
@@ -95,7 +96,10 @@
           "zapfdingbats" FontFactory/ZAPFDINGBATS
           FontFactory/HELVETICA))
 
-      BaseFont/WINANSI
+      (case [(not (nil? ttf-name)) encoding]
+        [true :unicode] BaseFont/IDENTITY_H
+        [true :default] BaseFont/WINANSI
+        BaseFont/WINANSI)
 
       true
 


### PR DESCRIPTION
Hi, @yogthos. I've added basic unicode support through font's :encoding option. Unicode is enabled if it's set to :unicode and :ttf-name is used. If :unicode isn't used or :default, BaseFont/WINANSI encoding is used instead. Maybe unicode should always be enabled when :ttf-name is used? I'm not sure. In any case, unicode support for vertival text should be added in future as well (BaseFont/IDENTITY_V).