### PR TITLE
Added support for custom size vector

### DIFF
--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -28,12 +28,13 @@
      Paragraph
      Phrase
      Rectangle
+     RectangleReadOnly
      RomanList
      Section
      Table
      ZapfDingbatsList
      ZapfDingbatsNumberList]
-    [com.lowagie.text.pdf BaseFont PdfContentByte PdfReader PdfStamper PdfWriter PdfPCell PdfPTable]
+    [com.lowagie.text.pdf BaseFont PdfContentByte PdfReader PdfStamper PdfWriter PdfPCell PdfPTable ]
     [java.io PushbackReader InputStream InputStreamReader FileOutputStream ByteArrayOutputStream]))
 
 (declare ^:dynamic *cache*)
@@ -113,60 +114,65 @@
         (new Color r g b)
         (new Color 0 0 0))))
 
+(defn- custom-page-size [width height]
+  (RectangleReadOnly. width height))
+
 (defn- page-size [size]
-  (condp = (when size (name size))
-    "a0"                        PageSize/A0
-    "a1"                        PageSize/A1
-    "a2"                        PageSize/A2
-    "a3"                        PageSize/A3
-    "a4"                        PageSize/A4
-    "a5"                        PageSize/A5
-    "a6"                        PageSize/A6
-    "a7"                        PageSize/A7
-    "a8"                        PageSize/A8
-    "a9"                        PageSize/A9
-    "a10"                       PageSize/A10
-    "arch-a"                    PageSize/ARCH_A
-    "arch-b"                    PageSize/ARCH_B
-    "arch-c"                    PageSize/ARCH_C
-    "arch-d"                    PageSize/ARCH_D
-    "arch-e"                    PageSize/ARCH_E
-    "b0"                        PageSize/B0
-    "b1"                        PageSize/B1
-    "b2"                        PageSize/B2
-    "b3"                        PageSize/B3
-    "b4"                        PageSize/B4
-    "b5"                        PageSize/B5
-    "b6"                        PageSize/B6
-    "b7"                        PageSize/B7
-    "b8"                        PageSize/B8
-    "b9"                        PageSize/B9
-    "b10"                       PageSize/B10
-    "crown-octavo"              PageSize/CROWN_OCTAVO
-    "crown-quarto"              PageSize/CROWN_QUARTO
-    "demy-octavo"               PageSize/DEMY_OCTAVO
-    "demy-quarto"               PageSize/DEMY_QUARTO
-    "executive"                 PageSize/EXECUTIVE
-    "flsa"                      PageSize/FLSA
-    "flse"                      PageSize/FLSE
-    "halfletter"                PageSize/HALFLETTER
-    "id-1"                      PageSize/ID_1
-    "id-2"                      PageSize/ID_2
-    "id-3"                      PageSize/ID_3
-    "large-crown-octavo"        PageSize/LARGE_CROWN_OCTAVO
-    "large-crown-quarto"        PageSize/LARGE_CROWN_QUARTO
-    "ledger"                    PageSize/LEDGER
-    "legal"                     PageSize/LEGAL
-    "letter"                    PageSize/LETTER
-    "note"                      PageSize/NOTE
-    "penguin-large-paperback"   PageSize/PENGUIN_LARGE_PAPERBACK
-    "penguin-small-paperback"   PageSize/PENGUIN_SMALL_PAPERBACK
-    "postcard"                  PageSize/POSTCARD
-    "royal-octavo"              PageSize/ROYAL_OCTAVO
-    "royal-quarto"              PageSize/ROYAL_QUARTO
-    "small-paperback"           PageSize/SMALL_PAPERBACK
-    "tabloid"                   PageSize/TABLOID
-    PageSize/A4))
+  (if (vector? size)
+    (apply custom-page-size size)
+    (condp = (when size (name size))
+      "a0"                        PageSize/A0
+      "a1"                        PageSize/A1
+      "a2"                        PageSize/A2
+      "a3"                        PageSize/A3
+      "a4"                        PageSize/A4
+      "a5"                        PageSize/A5
+      "a6"                        PageSize/A6
+      "a7"                        PageSize/A7
+      "a8"                        PageSize/A8
+      "a9"                        PageSize/A9
+      "a10"                       PageSize/A10
+      "arch-a"                    PageSize/ARCH_A
+      "arch-b"                    PageSize/ARCH_B
+      "arch-c"                    PageSize/ARCH_C
+      "arch-d"                    PageSize/ARCH_D
+      "arch-e"                    PageSize/ARCH_E
+      "b0"                        PageSize/B0
+      "b1"                        PageSize/B1
+      "b2"                        PageSize/B2
+      "b3"                        PageSize/B3
+      "b4"                        PageSize/B4
+      "b5"                        PageSize/B5
+      "b6"                        PageSize/B6
+      "b7"                        PageSize/B7
+      "b8"                        PageSize/B8
+      "b9"                        PageSize/B9
+      "b10"                       PageSize/B10
+      "crown-octavo"              PageSize/CROWN_OCTAVO
+      "crown-quarto"              PageSize/CROWN_QUARTO
+      "demy-octavo"               PageSize/DEMY_OCTAVO
+      "demy-quarto"               PageSize/DEMY_QUARTO
+      "executive"                 PageSize/EXECUTIVE
+      "flsa"                      PageSize/FLSA
+      "flse"                      PageSize/FLSE
+      "halfletter"                PageSize/HALFLETTER
+      "id-1"                      PageSize/ID_1
+      "id-2"                      PageSize/ID_2
+      "id-3"                      PageSize/ID_3
+      "large-crown-octavo"        PageSize/LARGE_CROWN_OCTAVO
+      "large-crown-quarto"        PageSize/LARGE_CROWN_QUARTO
+      "ledger"                    PageSize/LEDGER
+      "legal"                     PageSize/LEGAL
+      "letter"                    PageSize/LETTER
+      "note"                      PageSize/NOTE
+      "penguin-large-paperback"   PageSize/PENGUIN_LARGE_PAPERBACK
+      "penguin-small-paperback"   PageSize/PENGUIN_SMALL_PAPERBACK
+      "postcard"                  PageSize/POSTCARD
+      "royal-octavo"              PageSize/ROYAL_OCTAVO
+      "royal-quarto"              PageSize/ROYAL_QUARTO
+      "small-paperback"           PageSize/SMALL_PAPERBACK
+      "tabloid"                   PageSize/TABLOID
+      PageSize/A4)))
 
 (defn- page-orientation [page-size orientation]
   (if page-size


### PR DESCRIPTION
Hi, 
I had the need to have custom page sizes e.g. 18" x 18".

You should be able to pass a size options like so `:size [1296 1296]` to the 
core `pdf` function.

Questions:
- Was this possible and I glossed over it?
- The tests seem to be failing for me - any tips? I just get lots of reflection errors and all 20 assertions fail
- What is required to get this merged in: tests? (if you'd like to accept the PR).