### PR TITLE
Rename, fix and document :pad-until-even

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Use the CSS-like shortcut for applying classes to elements (e.g. `[:paragraph.fo
 [Chapter](#chapter),
 [Chart](#charting),
 [Chunk](#chunk),
+[Clear double page](#clear-double-page),
 [Graphics](#graphics),
 [Heading](#heading),
 [Image](#image),
@@ -438,6 +439,34 @@ Note that when using `:ttf-name`, you should set `:register-system-fonts? true` 
 [:chunk {:super true} "5"]
 
 [:chunk {:sub true} "2"]
+```
+
+#### Clear double page
+
+tag :clear-double-page
+
+Ends current page and inserts a blank page if necessary to ensure that subsequent content starts on the next odd-numbered page. In other words, if you print the resulting PDF on double-sided paper, the content that comes after a `:clear-double-page` will always be on a different sheet of paper from the content that came before it.
+
+```clojure
+;; Example documents
+
+[[:paragraph "this is on page 1"] [:clear-double-page] [:paragraph "this is on page 3"]]
+
+[[:paragraph "this is on page 1"] 
+ [:clear-double-page] [:clear-double-page] 
+ [:paragraph "this is on page 3"]]
+
+[[:paragraph "this is on page 1"] [:pagebreak] 
+ [:paragraph "this is on page 2"] [:clear-double-page] 
+ [:paragraph "this is on page 3"]]
+
+[[:paragraph "this is on page 1"] [:pagebreak] 
+ [:paragraph "this is on page 2"] [:pagebreak] 
+ [:paragraph "this is on page 3"] [:clear-double-page] 
+ [:paragraph "this is on page 5"]]
+
+;; :clear-double-page on an empty page 1 does nothing
+[[:clear-double-page] [:paragraph "This is on page 1"]]
 ```
 
 #### Graphics

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -720,7 +720,7 @@
 
 (declare append-to-doc)
 
-(defn- pad-until-even [stylesheet references font-style width height item doc pdf-writer]
+(defn- clear-double-page [stylesheet references font-style width height item doc pdf-writer]
   ;; The page number seems to be zero-indexed
   (when (odd? (+ 1 (.getPageNumber doc)))
     (doseq [item [[:pagebreak] [:paragraph " "] [:pagebreak]]]
@@ -729,7 +729,7 @@
 (defn- append-to-doc [stylesheet references font-style width height item doc pdf-writer]
   (cond
     (= [:pagebreak] item) (.newPage doc)
-    (= [:pad-until-even] item) (pad-until-even stylesheet references font-style width height item doc pdf-writer)
+    (= [:clear-double-page] item) (clear-double-page stylesheet references font-style width height item doc pdf-writer)
     :else (.add doc
                 (make-section
                  (assoc font-style

--- a/src/clj_pdf/core.clj
+++ b/src/clj_pdf/core.clj
@@ -721,10 +721,18 @@
 (declare append-to-doc)
 
 (defn- clear-double-page [stylesheet references font-style width height item doc pdf-writer]
-  ;; The page number seems to be zero-indexed
-  (when (odd? (+ 1 (.getPageNumber doc)))
-    (doseq [item [[:pagebreak] [:paragraph " "] [:pagebreak]]]
-      (append-to-doc stylesheet references font-style width height item doc pdf-writer))))
+  "End current page and make sure that subsequent content will start on
+     the next odd-numbered page, inserting a blank page if necessary."
+  (let [append (fn [item] (append-to-doc stylesheet references font-style width height item doc pdf-writer))]
+    ;; Inserting a :pagebreak starts a new page, unless we already happen to
+    ;; be on a blank page, in which case it does nothing;
+    (append [:pagebreak])
+    ;; in either case we're now on a blank page, and if it's even-numbered,
+    ;; we need to insert some whitespace to force the next :pagebreak to start
+    ;; a new, odd-numbered page.
+    (when (even? (.getPageNumber pdf-writer))
+      (append [:paragraph " "])
+      (append [:pagebreak]))))
 
 (defn- append-to-doc [stylesheet references font-style width height item doc pdf-writer]
   (cond


### PR DESCRIPTION
- Call the element `:clear-double-page` instead (inspired by LaTeX)
- Fix a trivial but fatal bug and a subtle corner case
- Add documentation

I made sure to test the examples that I added to the documentation, so I hope the new implementation actually works as advertised. :)