### PR TITLE
Add travis continuous integration / config & badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: clojure
+lein: lein2
+script: lein2 test
+jdk:
+  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: clojure
 lein: lein2
-script: lein2 test
+script:
+  - lein2 install
+  - lein2 test
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `clj-pdf`
+# `clj-pdf` [![Build Status](https://travis-ci.org/yogthos/clj-pdf.svg?branch=master)](http://travis-ci.org/yogthos/clj-pdf)
 
 A library for easily generating PDFs from Clojure. An example PDF is available [here](https://github.com/yogthos/clj-pdf/raw/master/example.pdf) with its source [below](#a-complete-example).
 


### PR DESCRIPTION
Hi @yogthos would be useful to get Travis to run the test on any push into github ... in order to make this work, you (as project owner) need to go into the project's webhooks/services settings (https://github.com/yogthos/clj-pdf/settings/hooks) and on the 'Add Services' pick travis CI - you may need to go and do authorize your github account on https://travis-ci.org/ too - cant remember the exact details, but once set up it will automatically schedule a build when new commits are pushed to any branch.