### PR TITLE
Add code coverage integration & badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: clojure
 lein: lein2
 script:
   - lein2 install
-  - lein2 test
+  - lein2 with-profile +dev cloverage --coveralls
+  - curl -F 'json_file=@target/coverage/coveralls.json' 'https://coveralls.io/api/v1/jobs'
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `clj-pdf` [![Build Status](https://travis-ci.org/yogthos/clj-pdf.svg?branch=master)](http://travis-ci.org/yogthos/clj-pdf)
+# `clj-pdf` [![Build Status](https://travis-ci.org/yogthos/clj-pdf.svg?branch=master)](http://travis-ci.org/yogthos/clj-pdf) [![Coverage Status](https://coveralls.io/repos/yogthos/clj-pdf/badge.svg?branch=master)](https://coveralls.io/r/yogthos/clj-pdf?branch=master)
 
 
 A library for easily generating PDFs from Clojure. An example PDF is available [here](https://github.com/yogthos/clj-pdf/raw/master/example.pdf) with its source [below](#a-complete-example).

--- a/project.clj
+++ b/project.clj
@@ -23,4 +23,5 @@
                                       [midje-readme "1.0.8"]]
                        :plugins      [[lein-marginalia "0.7.1"]
                                       [lein-midje "3.0.0"]
-                                      [midje-readme "1.0.2"]]}})
+                                      [midje-readme "1.0.2"]
+                                      [lein-cloverage "1.0.6"]]}})


### PR DESCRIPTION
Harvest coverage stats when the test run and post to https://coveralls.io - ~~to get to work you'd need to authorize with your github account.~~ nope seems like I can enable it : https://coveralls.io/builds/4833782