### PR TITLE
Bump clojure to 1.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :url          "http://www.gnu.org/licenses/lgpl.html"
             :distribution :repo}
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.jfree/jfreechart "1.0.19"]
                  [org.apache.xmlgraphics/batik-bridge "1.8"]
                  [org.apache.xmlgraphics/batik-anim "1.8"]


### PR DESCRIPTION


Tests seem to pass.
Is there anything that prevents the bump?
[test.txt](https://github.com/yogthos/clj-pdf/files/186553/test.txt)
