### PR TITLE
Add support for manually providing table header :cell elements

### DIFF
--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -417,7 +417,10 @@
           (let [^Element header-text (if (string? h)
                                        (make-section [:chunk {:style "bold"} h])
                                        (make-section h))
-                header-cell          (doto (new Cell header-text) (.setHeader true))]
+                ^Cell header-cell    (if (= Cell (type header-text))
+                                       header-text
+                                       (new Cell header-text))
+                header-cell          (doto header-cell (.setHeader true))]
             (when-not (and (string? h)
                            (map? (second h)))
               (when-let [align (:align (second h))]


### PR DESCRIPTION
This allows support for doing things such as adding `:colspan`'s to your
table headers.

e.g.

```clojure
(pdf
  [{}
   [:paragraph
    [:table
     {:header ["A" "B" [:cell {:colspan 2 :align :center} "Cell"]]}
     ["1a" "1b" "1c" "1d"]
     ["2a" "2b" "2c" "2d"]
     ["3a" "3b" "3c" "3d"]
     ["4a" "4b" "4c" "4d"]]]]
  "test.pdf")
```