### PR TITLE
Allow image elements to be included inline with surrounding text

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,7 +669,13 @@ optional metadata:
 [:image "test/mandelbrot.jpg"]
 [:image "http://clojure.org/space/showimage/clojure-icon.gif"]
 
+; images can also be inserted inline with other text by wrapping it inside
+; of a chunk element
+[:paragraph "hello, world!" [:chunk [:image "smiley.png"]]]
 
+; x and y values provided to the chunk are relative offsets for the image.
+; the image element itself still accepts it's normal properties shown above
+[:chunk {:x 10 :y 10} [:image {:width 16 :height 16} "smiley.png"]]
 ```
 
 #### Line

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -23,6 +23,7 @@
      GreekList
      HeaderFooter
      Image
+     ImgRaw
      List
      ListItem
      PageSize
@@ -251,14 +252,25 @@
     (.setFont (font meta))
     (.addAll (map (partial make-section meta) content))))
 
+(defn- image-chunk [meta ^Image image]
+  (new Chunk
+       image
+       (float (or (:x meta) 0))
+       (float (or (:y meta) 0))))
+
 (defn- text-chunk [style content]
-  (let [ch (new Chunk ^String (make-section content) (font style))]
+  (let [ch (new Chunk ^String (make-section content) ^Font (font style))]
     (set-background ch style)
     (cond
       (:super style) (.setTextRise ch (float 5))
       (:sub style) (.setTextRise ch (float -4))
       :else ch)))
 
+(defn- make-chunk [meta content]
+  (let [children (make-section content)]
+    (if (instance? ImgRaw children)
+      (image-chunk meta children)
+      (text-chunk meta children))))
 
 (defn- annotation
   ([_ title text] (annotation title text))
@@ -728,7 +740,7 @@
              :pdf-cell pdf-cell
              :chapter chapter
              :chart chart
-             :chunk text-chunk
+             :chunk make-chunk
              :heading heading
              :image image
              :graphics g2d/with-graphics


### PR DESCRIPTION
This change allows `:image` elements to be included inline with surrounding text contained in `:paragraph` or other `:chunk` elements by allowing an `:image` to be placed inside of a `:chunk` (as the sole content of that chunk).