### PR TITLE
Add :leading option support to table :cell elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,6 +1055,7 @@ tag :cell
 metadata:
 
 * :align :left, :center, :right, :justified
+* :leading number (line spacing is measured in 72 units per inch, default spacing is 1.5 times the font height)
 * :background-color `[r g b]` (int values)
 * :colspan number
 * :border boolean

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -300,6 +300,7 @@
                      border
                      align
                      valign
+                     leading
                      set-border
                      border-color
                      border-width
@@ -326,6 +327,7 @@
     (if border-width-top (.setBorderWidthTop c (float border-width-top)))
     (if valign (.setVerticalAlignment c ^int (get-alignment valign)))
     (.setHorizontalAlignment c ^int (get-alignment align))
+    (if leading (.setLeading c (float leading)))
 
     (doseq [item (map
                    #(make-section meta (if (string? %) [:chunk %] %))


### PR DESCRIPTION
Works exactly the same as it does in paragraphs and other text elements.