### PR TITLE
Use style on headers / footers

### DIFF
--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -991,8 +991,8 @@
     (let [reader    (new PdfReader (.toByteArray temp-stream))
           stamper   (new PdfStamper reader output-stream)
           num-pages (.getNumberOfPages reader)
-          base-font (or (some-> font-style font .getBaseFont)
-                        (BaseFont/createFont))
+          font      (-> font-style (or {}) (merge {:size 10 :color (:color footer)}) font)
+          base-font (.getBaseFont font)
           footer    (when (not= footer false)
                       (if (string? footer)
                         {:text footer :align :right :start-page 1}
@@ -1003,6 +1003,7 @@
             (doto (.getOverContent stamper (inc i))
               (.beginText)
               (.setFontAndSize base-font 10)
+              (.setColorFill (.getColor font))
               (.setTextMatrix
                 (align-footer width base-font footer) (float 20))
               (.showText (if total-pages

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -798,9 +798,9 @@
                     :pdf-writer pdf-writer)
                   (or item [:paragraph item])))))
 
-(defn- add-header [header ^Document doc]
+(defn- add-header [header ^Document doc font-style]
   (when header
-    (.setHeader doc (doto (new HeaderFooter (new Phrase header) false) (.setBorderWidthTop 0)))))
+    (.setHeader doc (doto (new HeaderFooter (new Phrase header (font font-style)) false) (.setBorderWidthTop 0)))))
 
 (defn table-footer-header-event [{:keys [table x y]}]
   (proxy [cljpdf.text.pdf.PdfPageEventHelper] []
@@ -890,6 +890,7 @@
         doc           (Document. (page-orientation (page-size size) orientation))
         width         (.. doc getPageSize getWidth)
         height        (.. doc getPageSize getHeight)
+        font-style    (or font-style (:font meta) {})
         output-stream (if (string? out) (FileOutputStream. ^String out) out)
         temp-stream   (if (page-events? meta) (ByteArrayOutputStream.))
         page-numbers? (not= false (:page-numbers footer))
@@ -926,7 +927,7 @@
           (.setPageEvent pdf-writer page-event))
         (if (or footer page-numbers?)
           (.setFooter doc
-                      (doto (new HeaderFooter (new Phrase (str (:text footer) " ") ^java.awt.Font (font {:size 10})) page-numbers?)
+                      (doto (new HeaderFooter (new Phrase (str (:text footer) " ") ^java.awt.Font (font font-style)) page-numbers?)
                         (.setBorder 0)
                         (.setAlignment ^int (get-alignment (:align footer)))))))
 
@@ -945,10 +946,10 @@
         (do
           (.open doc)
           (doseq [item letterhead]
-            (append-to-doc nil nil (or font-style {}) width height (if (string? item) [:paragraph item] item) doc pdf-writer))
-          (add-header header doc))
+            (append-to-doc nil nil font-style width height (if (string? item) [:paragraph item] item) doc pdf-writer))
+          (add-header header doc font-style))
         (do
-          (add-header header doc)
+          (add-header header doc font-style)
           (.open doc)))
 
       (if title (.addTitle doc title))

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -828,7 +828,7 @@
                          (assoc-in [:table] table)
                          (update-in [:x] #(or % (if footer? 36 (.left doc))))
                          (update-in [:y] #(or % (if footer? 64 (- (.top doc) (or top-margin 0))))))]
-    (.setPageEvent pdf-writer (table-footer-header-event content (and (not footer?) first-page?)))
+    (.setPageEvent pdf-writer (table-footer-header-event content (or footer? first-page?)))
     table-height))
 
 (defn set-margins [doc left-margin right-margin top-margin bottom-margin header-table-height footer-table-height]

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -409,7 +409,7 @@
     c))
 
 
-(defn- table-header [^Table tbl header cols]
+(defn- table-header [meta ^Table tbl header cols]
   (when header
     (let [meta?       (map? (first header))
           header-rest (if meta? (rest header) header)
@@ -419,8 +419,8 @@
       (if (= 1 (count header-data))
         (let [header               (first header-data)
               ^Element header-text (if (string? header)
-                                     (make-section [:chunk {:style "bold"} header])
-                                     (make-section header))
+                                     (make-section meta [:chunk {:style "bold"} header])
+                                     (make-section meta header))
               header-cell          (doto (new Cell header-text)
                                      (.setHorizontalAlignment 1)
                                      (.setHeader true)
@@ -430,8 +430,8 @@
 
         (doseq [h header-data]
           (let [^Element header-text (if (string? h)
-                                       (make-section [:chunk {:style "bold"} h])
-                                       (make-section h))
+                                       (make-section meta [:chunk {:style "bold"} h])
+                                       (make-section meta h))
                 ^Cell header-cell    (if (= Cell (type header-text))
                                        header-text
                                        (new Cell header-text))
@@ -483,7 +483,7 @@
     (.setPadding tbl (if padding (float padding) (float 3)))
     (if spacing (.setSpacing tbl (float spacing)))
     (if offset (.setOffset tbl (float offset)))
-    (table-header tbl header cols)
+    (table-header meta tbl header cols)
 
     (.setAlignment tbl ^int (get-alignment align))
 

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -1044,34 +1044,35 @@
     (write-total-pages width doc-meta temp-stream output-stream)))
 
 (defn- to-pdf [input-reader r out]
-  (let [doc-meta (input-reader r)
-        [^Document doc
-         width height
-         ^ByteArrayOutputStream temp-stream
-         ^OutputStream output-stream
-         ^PdfWriter pdf-writer] (setup-doc doc-meta out)]
+  (let [doc-meta (input-reader r)]
     (register-fonts doc-meta)
-    (loop []
-      (if-let [item (input-reader r)]
-        (do
-          (add-item item doc-meta width height doc pdf-writer)
-          (recur))
-        (do
-          (.close doc)
-          (write-total-pages width doc-meta temp-stream output-stream))))))
+    (let [[^Document doc
+           width height
+           ^ByteArrayOutputStream temp-stream
+           ^OutputStream output-stream
+           ^PdfWriter pdf-writer] (setup-doc doc-meta out)]
+      (loop []
+        (if-let [item (input-reader r)]
+          (do
+            (add-item item doc-meta width height doc pdf-writer)
+            (recur))
+          (do
+            (.close doc)
+            (write-total-pages width doc-meta temp-stream output-stream)))))))
 
 (defn- seq-to-doc [items out]
-  (let [doc-meta (first items)
-        [^Document doc
-         width height
-         ^ByteArrayOutputStream temp-stream
-         ^OutputStream output-stream
-         ^PdfWriter pdf-writer] (setup-doc doc-meta out)]
+  (let [doc-meta (first items)]
     (register-fonts doc-meta)
-    (doseq [item (rest items)]
-      (add-item item doc-meta width height doc pdf-writer))
-    (.close doc)
-    (write-total-pages width doc-meta temp-stream output-stream)))
+    (let [[^Document doc
+           width height
+           ^ByteArrayOutputStream temp-stream
+           ^OutputStream output-stream
+           ^PdfWriter pdf-writer] (setup-doc doc-meta out)]
+      (doseq [item (rest items)]
+        (add-item item doc-meta width height doc pdf-writer))
+      (.close doc)
+      (write-total-pages width doc-meta temp-stream output-stream))))
+
 
 (defn- stream-doc
   "reads the document from an input stream one form at a time and writes it out to the output stream

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -808,11 +808,11 @@
       (when-not (and (= (.getPageNumber doc) 1) (not first-page?))
         (.writeSelectedRows table (int 0) (int -1) (float x) (float y) (.getDirectContent writer)))
       ;;Reserve space for header table after page 1
-      (if (= (.getPageNumber doc) 1)
+      (if (and (= (.getPageNumber doc) 1) (not first-page?))
         (.setMargins doc
                      (float (.left doc))
                      (float (.left doc))
-                     (float y)
+                     (float (+ y (.getTotalHeight table)))
                      (float (.bottom doc)))))))
 
 (defn set-header-footer-table-width [table doc page-numbers?]

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -102,7 +102,7 @@
     (case [(not (nil? ttf-name))
            (if (keyword? encoding) encoding :custom)]
       [true :unicode] BaseFont/IDENTITY_H
-      [true :custom] encoding
+      [true :custom] (or encoding BaseFont/IDENTITY_H)
       [true :default] BaseFont/WINANSI
       BaseFont/WINANSI)
 

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -812,7 +812,7 @@
         (.setMargins doc
                      (float (.left doc))
                      (float (.left doc))
-                     (float (+ y (.getTotalHeight table)))
+                     (float (+ (.topMargin doc) (.getTotalHeight table)))
                      (float (.bottom doc)))))))
 
 (defn set-header-footer-table-width [table doc page-numbers?]


### PR DESCRIPTION
The default document font wasn't being sent to headers, I'm currently fixing this. I may need a few pointers, specially for trying to fix the Complex Header (when document header is defined as a table) and the stylesheets.

I've been using clojure for less than 3 months, so don't hesitate to criticize anything, I'm still learning. 😄 

These are the main TODOs I plan on doing for this PR:
- [x] Simple Header / Footer using default document font
- [x] Complex Header / Footer using default document font
- [x] Table Header using default document font
- [x] Make Complex Header not appear on first page when `:letterhead` is set
- [x] Make stylesheets work on Headers / Footers
- [x] Make stylesheets work on Table Headers (#100)