### PR TITLE
pdf-table and table element enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,6 +996,7 @@ metadata:
    and can also be formatted via a vector of paragraphs or phrases
 * :offset number
 * :num-cols number
+* :no-split-cells? boolean if true, will prevent cells (and rows) from being split across two pages. if a cell won't fit entirely on the current page, the row will be moved to the next page. default is false
 
 ```clojure
 [:table {:header ["Row 1" "Row 2" "Row 3"] :width 50 :border false :cell-border false}
@@ -1066,14 +1067,17 @@ that can either be strings, images, chunks, paragraphs, phrases, pdf-cells, or o
 metadata:
 
 * :background-color `[r g b]`
-* :spacing-before number
-* :spacing-after number
+* :spacing-before number spacing before the table
+* :spacing-after number spacing after the table
 * :cell-border boolean
 * :bounding-box `[width height]`
-* :horizontal-align :left, :rigth, :center, :justified
+* :horizontal-align :left, :right, :center, :justified
 * :title string
 * :width number
 * :width-percent number (0-100)
+* :num-cols number manually specify the number of columns in the table. if not specified this will be automatically set to the maximum number of columns that appear in any row in the table.
+* :keep-together? boolean if true, attempts to keep the entire table on the same page. if there is not enough room on the current page, the table will be moved to the next page. will not work if the table is too large for any single page. default is false
+* :no-split-rows? boolean if true, if a row won't fit in the space remaining on the current page, it will be moved to the next page instead of the cells being split between two pages. default is false
 
 ```clojure
 [:pdf-table
@@ -1084,6 +1088,15 @@ metadata:
   ["foo" [:chunk {:style :bold} "bar"] [:phrase "baz"]]
   [[:pdf-cell "foo"] [:pdf-cell "foo"] [:pdf-cell "foo"]]
   [[:pdf-cell "foo"] [:pdf-cell "foo"] [:pdf-cell "foo"]]]
+
+; if the widths vector that normally would be after the metadata map is nil, the
+; pdf-table's column widths will be automatically figured out (evenly spaced)
+[:pdf-table
+  {:width-percent 100}
+  nil
+  ["a" "b" "c"]
+  ["1" "2" "3"]
+  ["i" "ii" "iii"]]
 ```
 
 #### Table Cell

--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,8 @@ that can either be strings, images, chunks, paragraphs, phrases, pdf-cells, or o
 
 metadata:
 
+* :header a vector containing one or more row vectors (of the same format as normal table rows) that will be used as the header for the table
+* :footer same as :header, but for footer rows
 * :background-color `[r g b]`
 * :spacing-before number spacing before the table
 * :spacing-after number spacing after the table
@@ -1097,6 +1099,17 @@ metadata:
   ["a" "b" "c"]
   ["1" "2" "3"]
   ["i" "ii" "iii"]]
+  
+; table with 2 header rows, 3 regular content rows
+[:pdf-table
+  {:header [[[:pdf-cell {:colspan 2} 
+              [:paragraph {:align :center :style :bold} "Customer Orders"]]]
+            [[:phrase {:style :bold} "Name"]
+             [:phrase {:style :bold} "Order Amount"]]]}
+  [50 50]
+  ["Joe" "$20.00"]
+  ["Bob" "$7.50"]
+  ["Mary" "$18.90"]]
 ```
 
 #### Table Cell

--- a/src/clj/clj_pdf/core.clj
+++ b/src/clj/clj_pdf/core.clj
@@ -457,7 +457,19 @@
                   :else [:cell content])]
     (.addCell tbl ^Cell (make-section meta element))))
 
-(defn- table [{:keys [background-color spacing padding offset header border border-width cell-border width widths align num-cols]
+(defn- table [{:keys [align
+                      background-color
+                      border
+                      border-width
+                      cell-border
+                      header
+                      no-split-cells?
+                      num-cols
+                      offset
+                      padding
+                      spacing
+                      width
+                      widths]
                :as   meta}
               & rows]
   (when (< (count rows) 1) (throw (new Exception "Table must contain rows!")))
@@ -486,6 +498,8 @@
     (table-header meta tbl header cols)
 
     (.setAlignment tbl ^int (get-alignment align))
+
+    (.setCellsFitPage tbl (boolean no-split-cells?))
 
     (doseq [row rows]
       (doseq [column row]


### PR DESCRIPTION
For `:table` adds a `:no-split-cells?` boolean property that controls whether cells (and hence, rows) will be split between pages if there is not enough room left on the current page. Defaults to current existing behaviour (allowing splits).

For `:pdf-table`:

- Similar to the above, adds `:no-split-cells?` with the same functionality
- `:keep-together?` which if true, will attempt to keep the entire table on the same page (moving to the next page if necessary).
- `:header` and `:footer` rows
- The `widths` vector can now be specified as `nil` in which case, the column widths will be automatically figured out (evenly distributed)
