### PR TITLE
add PdfPageEvent.onBeforePageStart

### DIFF
--- a/src/java/cljpdf/text/pdf/PdfPageEvent.java
+++ b/src/java/cljpdf/text/pdf/PdfPageEvent.java
@@ -71,6 +71,19 @@ public interface PdfPageEvent {
  */
     public void onOpenDocument(PdfWriter writer, Document document);
 
+
+/**
+ * Called before a new page is about to be initialized.
+ * <P>
+ * This event allows for doing things such as resetting page margins
+ * or size, etc between pages, as it is too late to do certain adjustments
+ * in <CODE>onStartPage</CODE> and <CODE>onEndPage</CODE>.
+ *
+ * @param writer the <CODE>PdfWriter</CODE> for this document
+ * @param document the document
+ */
+    public void onBeforeStartPage(PdfWriter writer, Document document);
+
 /**
  * Called when a page is initialized.
  * <P>

--- a/src/java/cljpdf/text/pdf/PdfPageEventHelper.java
+++ b/src/java/cljpdf/text/pdf/PdfPageEventHelper.java
@@ -74,6 +74,19 @@ public class PdfPageEventHelper implements PdfPageEvent {
     }
 
 /**
+ * Called before a new page is about to be initialized.
+ * <P>
+ * This event allows for doing things such as resetting page margins
+ * or size, etc between pages, as it is too late to do certain adjustments
+ * in <CODE>onStartPage</CODE> and <CODE>onEndPage</CODE>.
+ *
+ * @param writer the <CODE>PdfWriter</CODE> for this document
+ * @param document the document
+ */
+    public void onBeforeStartPage(PdfWriter writer, Document document) {
+    }
+
+/**
  * Called when a page is initialized.
  * <P>
  * Note that if even if a page is not written this method is still

--- a/src/java/cljpdf/text/pdf/events/PdfPageEventForwarder.java
+++ b/src/java/cljpdf/text/pdf/events/PdfPageEventForwarder.java
@@ -95,6 +95,24 @@ public class PdfPageEventForwarder implements PdfPageEvent {
 	}
 
 	/**
+	 * Called before a new page is about to be initialized.
+	 * <P>
+	 * This event allows for doing things such as resetting page margins
+	 * or size, etc between pages, as it is too late to do certain adjustments
+	 * in <CODE>onStartPage</CODE> and <CODE>onEndPage</CODE>.
+	 *
+	 * @param writer the <CODE>PdfWriter</CODE> for this document
+	 * @param document the document
+	 */
+	public void onBeforeStartPage(PdfWriter writer, Document document) {
+		PdfPageEvent event;
+		for (Iterator i = events.iterator(); i.hasNext(); ) {
+			event = (PdfPageEvent)i.next();
+			event.onBeforeStartPage(writer, document);
+		}
+	}
+
+	/**
 	 * Called when a page is initialized.
 	 * <P>
 	 * Note that if even if a page is not written this method is still called.


### PR DESCRIPTION
This event is useful to do per-page adjustments to page size and margins, etc. These types of page properties cannot be changed in `onStartPage` or `onEndPage` for the _current_ page... instead, they would take effect in the _next_ page.

Can be used like other `page-events`, by using the `PdfPageEventHelper` class, e.g.:

```clojure
(proxy [cljpdf.text.pdf.PdfPageEventHelper] []
  (onBeforeStartPage [writer doc]
    ; do stuff here
    ))
```

One slight oddity, is that this new event will fire _before_ the `onOpenDocument` event for the first page of the document. `onOpenDocument` fires too late unfortunately and I was worried about potentially breaking backward-compatibility for anyone that might be making heavy use of `page-events` with clj-pdf.